### PR TITLE
added docker information

### DIFF
--- a/content/en/cli/overview.md
+++ b/content/en/cli/overview.md
@@ -33,7 +33,7 @@ Follow the steps below:
 
 **Step 1.** [**Install Horusec**]({{< ref path="/cli/installation.md" lang="en">}});
 
-**Step 2.** Check the [requirements]({{< ref path="/cli/installation/#requirements" lang="en">}}) and run the command below in the location where your project is:
+**Step 2.** Check the [requirements]({{< ref path="/cli/installation" lang="en">}}) and run the command below in the location where your project is:
 
 ```bash
 horusec start

--- a/content/en/cli/overview.md
+++ b/content/en/cli/overview.md
@@ -33,7 +33,7 @@ Follow the steps below:
 
 **Step 1.** [**Install Horusec**]({{< ref path="/cli/installation.md" lang="en">}});
 
-**Step 2.** Run the command below where your project is:
+**Step 2.** Check the [requirements]({{< ref path="/cli/installation/#requirements" lang="en">}}) and run the command below in the location where your project is:
 
 ```bash
 horusec start

--- a/content/pt-br/cli/overview.md
+++ b/content/pt-br/cli/overview.md
@@ -34,9 +34,9 @@ Depois disso, você pode fazer a [**gestão de vulnerabilidade**]({{< ref path="
 ## **Como fazer uma análise?**
 Siga os passos abaixo: 
 
-**Passo 1.** [**Instale o Horusec**]({{< ref path="/cli/installation" lang="pt-br">}}) no seu computador; 
+**Passo 1.** [**Instale o Horusec**]({{< ref path="/cli/installation" lang="pt-br">}}) no seu computador;
 
-**Passo 2.** Rode o comando abaixo no local onde está seu projeto:
+**Passo 2.** Rode o comando abaixo no local onde está seu projeto, lembre-se de estar com o docker rodando:
 
 ```bash
 horusec start

--- a/content/pt-br/cli/overview.md
+++ b/content/pt-br/cli/overview.md
@@ -36,7 +36,7 @@ Siga os passos abaixo:
 
 **Passo 1.** [**Instale o Horusec**]({{< ref path="/cli/installation" lang="pt-br">}}) no seu computador;
 
-**Passo 2.** Rode o comando abaixo no local onde está seu projeto, lembre-se de estar com o docker rodando:
+**Passo 2.** Verifique os [requisitos]({{< ref path="/cli/installation/#requisitos" lang="pt-br">}}) e rode o comando abaixo no local onde está seu projeto:
 
 ```bash
 horusec start

--- a/content/pt-br/cli/overview.md
+++ b/content/pt-br/cli/overview.md
@@ -36,7 +36,7 @@ Siga os passos abaixo:
 
 **Passo 1.** [**Instale o Horusec**]({{< ref path="/cli/installation" lang="pt-br">}}) no seu computador;
 
-**Passo 2.** Verifique os [requisitos]({{< ref path="/cli/installation/#requisitos" lang="pt-br">}}) e rode o comando abaixo no local onde está seu projeto:
+**Passo 2.** Verifique os [requisitos]({{< ref path="/cli/installation" lang="pt-br">}}) e rode o comando abaixo no local onde está seu projeto:
 
 ```bash
 horusec start


### PR DESCRIPTION
When following the manual to do an analysis, I noticed that the command "horusec start" returns: "ERROR[0002] {HORUSEC_CLI} Error when check if docker is running in requirements, output: error="WARNING: Error loading config file: / Users/xxx/.docker/config.json: EOF\nCannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n"" if you don't have the docker running I think it's valid to inform it before running start.

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/docs-horusec/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**: information complement

**- How to verify it**: should see step 2 in /cli/overview/

**- Description for the changelog**: documentation improvement
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
