### PR TITLE
Removed line that is causing trouble at github-actions.

### DIFF
--- a/content/en/cli/installation.md
+++ b/content/en/cli/installation.md
@@ -140,8 +140,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-        with: # Required when commit authors is enabled
-          fetch-depth: 0
     - name: Running Horusec Security
       run: |
         curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest

--- a/content/pt-br/cli/installation.md
+++ b/content/pt-br/cli/installation.md
@@ -141,8 +141,6 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-        with: # Necessário quando habilitado o autores de commit
-          fetch-depth: 0
     - name: Running Horusec Security
       run: |
         curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest


### PR DESCRIPTION
lines: (with: # Required when commit authors is enabled, fetch-depth:0) are causing troubles

discovered this error trying to add github-actions to a project
(https://github.com/filipemelo/awesome-app-test/runs/4053280404?check_suite_focus=true)
(https://github.com/filipemelo/awesome-app-test/blob/main/.github/workflows/main.yml)

Signed-off-by: filipemelo <filipemelo.br@gmail.com>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/docs-horusec/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Tryed to follow what was written about Github-Actions, and got failure. So I removed the parts on english and portuguese documentation.

**- How to verify it**
Add the code below to any project on github actions on v2:
```
name: SecurityPipeline

on: [push]

jobs:
  horusec-security:
    name: horusec-security
    runs-on: ubuntu-latest
    steps:
    - name: Check out code
      uses: actions/checkout@v2
        with: # Necessário quando habilitado o autores de commit
          fetch-depth: 0
    - name: Running Horusec Security
      run: |
        curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
        horusec start -p="./" -e="true"       
```

**- Description for the changelog**
I removed the line that was causing trouble, and is running at a demo project.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
