### PR TITLE
Update Installing CLI content and Horusec-CLI version

### DIFF
--- a/content/en/cli/analysis-tools/overview.md
+++ b/content/en/cli/analysis-tools/overview.md
@@ -24,15 +24,15 @@ See below:
 
 | **Tools** | **Version** |
 | :--- | :--- |
-| Horusec-Leaks |v2.6.5 |
-| Horusec-Java |v2.6.5  | 
-| Horusec Kotlin |v2.6.5 |
-| Horusec-Kubernetes |v2.6.5| 
-| Horusec-NodeJS |v2.6.5 |
-| Horusec-CSharp |v2.6.5| 
-| Horusec Dart |v2.6.5|
-| Horusec Nginx |v2.6.5| 
-| Horusec Swift |v2.6.5| 
+| Horusec-Leaks |v2.6.9 |
+| Horusec-Java |v2.6.9  | 
+| Horusec Kotlin |v2.6.9 |
+| Horusec-Kubernetes |v2.6.9| 
+| Horusec-NodeJS |v2.6.9 |
+| Horusec-CSharp |v2.6.9| 
+| Horusec Dart |v2.6.9|
+| Horusec Nginx |v2.6.9| 
+| Horusec Swift |v2.6.9| 
 
 
 ## **Available programming languages and tools** 

--- a/content/en/cli/commands-and-flags.md
+++ b/content/en/cli/commands-and-flags.md
@@ -627,6 +627,14 @@ On the table below, you can see all the available flags. To see it better, just 
             <td style="text-align:left">Vulnerability</td>
             <td style="text-align:left">Used to show the vulnerabilities of the reported types. Example --show-vulnerabilities-types="Vulnerability, Risk Accepted, Corrected".</td>
         </tr>
+         <tr>
+            <td style="text-align:left">GITHUB_TOKEN</td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left">This environment variable is consumed by tools that require integration with Github's APIs as the <a href="https://github.com/sonatype-nexus-community/nancy">Nancy</a> in order to avoid the "rate-limiting" error</td>
+        </tr>
   </tbody>
 </table>
 

--- a/content/en/cli/installation.md
+++ b/content/en/cli/installation.md
@@ -68,22 +68,22 @@ See the latest versions below:
 
 | Operational system | Processor Architecture | Binary Type | Download |
 |---------------------|----------------------------|-----------------|----------|
-| Linux               | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64) |
-| Linux               | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64) |
-| Linux               | amd64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64.deb) |
-| Linux               | arm64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64.deb) |
-| Linux               | amd64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64.rpm) |
-| Linux               | arm64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64.rpm) |
-| Linux               | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64_stand_alone) |
-| Linux               | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64_stand_alone) |
-| Mac                 | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_amd64) |
-| Mac                 | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_arm64) |
-| Mac                 | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_amd64_stand_alone) |
-| Mac                 | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_arm64_stand_alone) |
-| Windows             | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_amd64.exe) |
-| Windows             | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_arm64.exe) |
-| Windows             | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_amd64_stand_alone.exe) |
-| Windows             | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_arm64_stand_alone.exe) |
+| Linux               | amd64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64) |
+| Linux               | arm64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64) |
+| Linux               | amd64                      | Installer debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64.deb) |
+| Linux               | arm64                      | Installer debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64.deb) |
+| Linux               | amd64                      | Installer rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64.rpm) |
+| Linux               | arm64                      | Installer rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64.rpm) |
+| Linux               | amd64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64_stand_alone) |
+| Linux               | arm64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64_stand_alone) |
+| Mac                 | amd64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_amd64) |
+| Mac                 | arm64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_arm64) |
+| Mac                 | amd64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_amd64_stand_alone) |
+| Mac                 | arm64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_arm64_stand_alone) |
+| Windows             | amd64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_amd64.exe) |
+| Windows             | arm64                      | Binary normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_arm64.exe) |
+| Windows             | amd64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_amd64_stand_alone.exe) |
+| Windows             | arm64                      | Binary Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_arm64_stand_alone.exe) |
 
 
 {{% alert color="info" %}}
@@ -109,6 +109,19 @@ chmod +x path/horusec_[your version here]
 
 👉[**All available versions**](https://github.com/ZupIT/horusec/releases)
 
+{{% alert color="warning" %}}
+If you received the following message in your analysis:
+```bash
+{HORUSEC_CLI} Nancy tool failed to query the GitHub API for updates.
+This is most likely due to GitHub rate-limiting on unauthenticated requests.
+To make authenticated requests please:
+  1. Generate a token at https://github.com/settings/tokens
+  2. Set the token by setting the GITHUB_TOKEN environment variable.
+Instructions for generating a token can be found at:
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line.
+```
+Do not worry, just add the following environment variable `GITHUB_TOKEN` with its value as follows [this documentation](https://docs.github.com/articles/creating-a-personal-access-token-for-the-command-line).
+{{% /alert %}}
 
 ## **Installation via Docker Image**
 
@@ -121,7 +134,10 @@ See some use cases below:
 When you initialize the image with the `run` command, just run Horusec with the command you want.
 
 ```bash
-docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src horuszup/horusec-cli:latest horusec start -p /src -P $(pwd)
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $(pwd):/src/horusec \
+        -e=GITHUB_TOKEN=$GITHUB_TOKEN \
+        horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd) --config-file-path=/src/horusec/horusec-config.json
 ```
 
 {{% alert color="warning" %}}
@@ -151,38 +167,46 @@ jobs:
       with: # Required when commit authors is enabled
         fetch-depth: 0
     - name: Running Horusec Security
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
         horusec start -p="./" -e="true"
 ```
 
 ### **AWS Code Build**
+Set environment variable `GITHUB_TOKEN` [into your project](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.env.secrets-manager) and add this configuration.
+
+* **Origin**
+  - Git Clone Depth: `Full`
 
 * **Environment:**
 
-  * Managed image
-  * Operational sytem: `Ubuntu`
-  * Execution time: `Standard`
-  * Image: `aws/codebuild/standard:3.0`
-  * Image Version:  `Latest`
-  * Environment type:  `Linux`
+  * Environment image: `Managed image`
+  * Operational System: `Ubuntu`
+  * Runtime: `Standard`
+  * Image: `aws/codebuild/standard:5.0`
+  * Image version:  `Always use the most recent image for this version of runtime`
+  * Environment Type:  `Linux`
   * Enable this indicator if you want to create Docker images or want your builds to get elevated privileges:  `true`
+  * Environment variables:
+     - Name: `GITHUB_TOKEN`
+     - Value: `TestSecret:MY_GITHUB_TOKEN`
+     - Type: `Secret Manager`
 
-* Buildspec:
-
+* **Buildspec**:
+  - Switch to the editor and insert compilation commands:
 ```yaml
 version: 0.2
 
 phases:
-  install:
-    runtime-versions:
-      docker: 18
   build:
     commands:
-      - docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src/horusec horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd)
+      - docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src/horusec -e=GITHUB_TOKEN=$GITHUB_TOKEN horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd) --config-file-path=/src/horusec/horusec-config.json
 ```
 
 ### **Circle CI**
+Set environment variable `GITHUB_TOKEN` [into your project](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) and add this configuration.
 
 ```yaml
 version: 2.1
@@ -209,6 +233,7 @@ workflows:
 ```
 
 ### **Jenkins**
+Set environment variable `GITHUB_TOKEN` [into your project](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials) and add this configuration.
 
 {{% alert color="warning" %}}
 In machines that use Jenkins should have the **docker and git installed** so that Horusec has all power in their analyzes.Check for more information at the [requirements of CLI](#Requirements).
@@ -226,17 +251,22 @@ stages {
 ```
 
 ### **Azure DevOps Pipeline**
+Set environment variable `GITHUB_TOKEN` [into your project](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables) and add this configuration.
 
 ```yaml
 pool:
   vmImage: 'ubuntu-18.04'
 
 steps:
-- script: curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && horusec start -p ./
+- script: |
+    curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
+    horusec start -p ./
+  env:
+    GITHUB_TOKEN: $(GITHUB_TOKEN)
 ```
 
 ### **GitLab CI/CD**
-
+Set environment variable `GITHUB_TOKEN` [into your project](https://docs.gitlab.com/ee/ci/variables/#view-all-group-level-variables-available-in-a-project) and add this configuration.
 ```yaml
 image: docker:latest
 

--- a/content/pt-br/cli/analysis-tools/overview.md
+++ b/content/pt-br/cli/analysis-tools/overview.md
@@ -25,15 +25,15 @@ A versão da CLI corresponde a versão das ferramentas criadas pelo time do Horu
 
 | **Ferramenta** | **Versão** |
 | :--- | :--- |
-| Horusec-Leaks |v2.6.5 |
-| Horusec-Java |v2.6.5  | 
-| Horusec Kotlin |v2.6.5 |
-| Horusec-Kubernetes |v2.6.5| 
-| Horusec-NodeJS |v2.6.5 |
-| Horusec-CSharp |v2.6.5| 
-| Horusec Dart |v2.6.5|
-| Horusec Nginx |v2.6.5| 
-| Horusec Swift |v2.6.5| 
+| Horusec-Leaks |v2.6.9 |
+| Horusec-Java |v2.6.9  | 
+| Horusec Kotlin |v2.6.9 |
+| Horusec-Kubernetes |v2.6.9| 
+| Horusec-NodeJS |v2.6.9 |
+| Horusec-CSharp |v2.6.9| 
+| Horusec Dart |v2.6.9|
+| Horusec Nginx |v2.6.9| 
+| Horusec Swift |v2.6.9| 
 
 
 ## **Linguagens de programação e ferramentas disponíveis**

--- a/content/pt-br/cli/commands-and-flags.md
+++ b/content/pt-br/cli/commands-and-flags.md
@@ -563,6 +563,14 @@ Na tabela abaixo, você confere todas as flags disponíveis. Para melhor visuali
             <td style="text-align:left">Vulnerability</td>
             <td style="text-align:left">Usado para mostrar as vulnerabilidades dos tipos informados. Exemplo --show-vulnerabilities-types="Vulnerability, Risk Accepted, Corrected".</td>
         </tr>
+         <tr>
+            <td style="text-align:left">GITHUB_TOKEN</td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left"></td>
+            <td style="text-align:left">Esta variável de ambiente é consumida por ferramentas que necessitam de uma integração com as API's do Github como o <a href="https://github.com/sonatype-nexus-community/nancy">Nancy</a> a fim de evitar o erro "limitante de taxa"</td>
+        </tr>
     </tbody>
 </table>
 

--- a/content/pt-br/cli/installation.md
+++ b/content/pt-br/cli/installation.md
@@ -69,22 +69,22 @@ Veja as últimas versões abaixo:
 
 | Sistema Operacional | Arquitetura de processador | Tipo de Binário | Download |
 |---------------------|----------------------------|-----------------|----------|
-| Linux               | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64) |
-| Linux               | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64) |
-| Linux               | amd64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64.deb) |
-| Linux               | arm64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64.deb) |
-| Linux               | amd64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64.rpm) |
-| Linux               | arm64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64.rpm) |
-| Linux               | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_amd64_stand_alone) |
-| Linux               | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_linux_arm64_stand_alone) |
-| Mac                 | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_amd64) |
-| Mac                 | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_arm64) |
-| Mac                 | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_amd64_stand_alone) |
-| Mac                 | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_mac_arm64_stand_alone) |
-| Windows             | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_amd64.exe) |
-| Windows             | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_arm64.exe) |
-| Windows             | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_amd64_stand_alone.exe) |
-| Windows             | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.5/horusec_win_arm64_stand_alone.exe) |
+| Linux               | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64) |
+| Linux               | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64) |
+| Linux               | amd64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64.deb) |
+| Linux               | arm64                      | Instalador debian normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64.deb) |
+| Linux               | amd64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64.rpm) |
+| Linux               | arm64                      | Instalador rpm normal | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64.rpm) |
+| Linux               | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_amd64_stand_alone) |
+| Linux               | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_linux_arm64_stand_alone) |
+| Mac                 | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_amd64) |
+| Mac                 | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_arm64) |
+| Mac                 | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_amd64_stand_alone) |
+| Mac                 | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_mac_arm64_stand_alone) |
+| Windows             | amd64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_amd64.exe) |
+| Windows             | arm64                      | Binário normal  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_arm64.exe) |
+| Windows             | amd64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_amd64_stand_alone.exe) |
+| Windows             | arm64                      | Binário Stand Alone  | [📥 Download](https://github.com/ZupIT/horusec/releases/download/v2.6.9/horusec_win_arm64_stand_alone.exe) |
 
 {{% alert color="info" %}}
 Se você quiser uma versão específica, troque a palavra `latest` no link pela versão que você precisa.
@@ -110,6 +110,20 @@ chmod +x path/horusec_[your version here]
 👉[**Todas as versões disponíveis** ](https://github.com/ZupIT/horusec/releases)
 
 
+{{% alert color="warning" %}}
+Se você recebeu a seguinte mensagem em sua análise:
+```bash
+{HORUSEC_CLI} Nancy tool failed to query the GitHub API for updates.
+This is most likely due to GitHub rate-limiting on unauthenticated requests.
+To make authenticated requests please:
+  1. Generate a token at https://github.com/settings/tokens
+  2. Set the token by setting the GITHUB_TOKEN environment variable.
+Instructions for generating a token can be found at:
+https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line.
+```
+Não se preocupe, basta você adicionar a seguinte variável de ambiente `GITHUB_TOKEN` com seu valor como segue [nesta documentação](https://docs.github.com/articles/creating-a-personal-access-token-for-the-command-line).
+{{% /alert %}}
+
 ## **Instalação via Imagem Docker**
 
 Esta forma de instalação permite que você realize suas análises por meio de uma imagem docker, você pode rodar localmente ou utilizando sua pipeline. 
@@ -122,12 +136,11 @@ Veja alguns casos de uso:
 Quando você inicializa a imagem com o comando run, basta executar o Horusec com o comando que você deseja:
 
 ```bash
-docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src horuszup/horusec-cli:latest horusec start -p /src -P $(pwd)
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $(pwd):/src/horusec \
+        -e=GITHUB_TOKEN=$GITHUB_TOKEN \
+        horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd) --config-file-path=/src/horusec/horusec-config.json
 ```
-
-{{% alert color="warning" %}}
-Verifique se o ambiente que você está trabalhando permite a criação de um volume bidirecional, isso é necessário para você usar o Horusec na imagem docker.
-{{% /alert %}}
 
 ### **2. Instalação via Pipeline**
 
@@ -152,38 +165,46 @@ jobs:
       with: # Necessário quando habilitado o autores de commit
         fetch-depth: 0
     - name: Running Horusec Security
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
         horusec start -p="./" -e="true"
 ```
 
 ### **AWS Code Build**
+Adicione a variável de ambiente `GITHUB_TOKEN` [dentro do seu projeto](https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build-spec.env.secrets-manager) e adicione esta configuração.
 
-* **Environment:**
+* **Origem**
+  - Profundidade do clone de Git: `Full`
+
+* **Ambiente:**
 
   * Imagem de ambiente: `Imagem gerenciada`
   * Sistema operational: `Ubuntu`
   * Tempo(s) de execução: `Standard`
-  * Imagem: `aws/codebuild/standard:3.0`
-  * Versão de imagem:  `Latest`
+  * Imagem: `aws/codebuild/standard:5.0`
+  * Versão de imagem:  `Usar sempre a imagem mais recente para esta versão do tempo de execução`
   * Tipo de ambiente:  `Linux`
   * Habilite esse indicador se você quiser criar imagens do Docker ou quiser que suas compilações obtenham privilégios elevados:  `true`
+  * Variáveis de ambiente:
+     - Nome: `GITHUB_TOKEN`
+     - Valor: `TestSecret:MY_GITHUB_TOKEN`
+     - Tipo: `Secret Manager`
 
-* Buildspec:
-
+* **Buildspec**:
+  - Alterne para o editor e inserira comandos de compilação:
 ```yaml
 version: 0.2
 
 phases:
-  install:
-    runtime-versions:
-      docker: 18
   build:
     commands:
-      - docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src/horusec horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd)
+      - docker run -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd):/src/horusec -e=GITHUB_TOKEN=$GITHUB_TOKEN horuszup/horusec-cli:latest horusec start -p /src/horusec -P $(pwd) --config-file-path=/src/horusec/horusec-config.json
 ```
 
 ### **Circle CI**
+Adicione a variável de ambiente `GITHUB_TOKEN` [dentro do seu projeto](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) e adicione esta configuração.
 
 ```yaml
 version: 2.1
@@ -211,6 +232,8 @@ workflows:
 
 ### **Jenkins**
 
+Adicione a variável de ambiente `GITHUB_TOKEN` [dentro do seu projeto](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables) e adicione esta configuração.
+
 {{% alert color="warning" %}}
 Em máquinas que utilizam Jenkins deve-se ter o **docker e git instalado** para que o Horusec tenha toda potencia em suas análises. Verifique mais informações na sessão de [requisitos da CLI](#Requisitos).
 {{% /alert %}}
@@ -228,15 +251,22 @@ stages {
 
 ### **Azure DevOps Pipeline**
 
+Adicione a variável de ambiente `GITHUB_TOKEN` [dentro do seu projeto](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables) e adicione esta configuração.
+
 ```yaml
 pool:
   vmImage: 'ubuntu-18.04'
 
 steps:
-- script: curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest && horusec start -p ./
+- script: |
+    curl -fsSL https://raw.githubusercontent.com/ZupIT/horusec/main/deployments/scripts/install.sh | bash -s latest
+    horusec start -p ./
+  env:
+    GITHUB_TOKEN: $(GITHUB_TOKEN)
 ```
 
 ### **GitLab CI/CD**
+Adicione a variável de ambiente `GITHUB_TOKEN` [dentro do seu projeto](https://docs.gitlab.com/ee/ci/variables/#view-all-group-level-variables-available-in-a-project) e adicione esta configuração.
 
 ```yaml
 image: docker:latest


### PR DESCRIPTION
I updated installing content of the pipelines because in the version v2.7.0 of the Horusec-CLI will be required this environment variable to run Nancy Tool in GoLang Projects.
I updated all references of the horusec-cli version 2.6.5 to 2.6.8 latest version

Signed-off-by: wilian <wilian.silva@zup.com.br>
