### PR TITLE
Fix the syntax error in horusec-config.json file

### DIFF
--- a/content/en/cli/commands-and-flags.md
+++ b/content/en/cli/commands-and-flags.md
@@ -212,9 +212,7 @@ See next, an example of a configuration file:
         },
          "Nancy": {
             "istoignore": false
-   },
-
-
+        }
     },
     "horusecCliWorkDir": {
     "go": [],


### PR DESCRIPTION
Fix the syntax error in the json file by removing the ,

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/docs-horusec/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
