### PR TITLE
Fixed typos on the CLI' log-level global flag description

### DIFF
--- a/content/en/cli/commands-and-flags.md
+++ b/content/en/cli/commands-and-flags.md
@@ -30,7 +30,7 @@ The current global flags on CLI are:
         <p>This configuration will define which log level you want to view, it can be:</p>
         <ul>
           <li>&quot;panic&quot;</li>
-          <li>fatal&quot;</li>
+          <li>&quot;fatal&quot;</li>
           <li>&quot;error&quot;</li>
           <li>&quot;warn&quot;</li>
           <li>&quot;info&quot;</li>

--- a/content/pt-br/cli/commands-and-flags.md
+++ b/content/pt-br/cli/commands-and-flags.md
@@ -30,7 +30,7 @@ As flags globais que atualmente temos em nossa CLI são:
         <p>Essa configuração irá definir qual é o nível de log que você deseja visualizar, podem estar entre:</p>
         <ul>
           <li>&quot;panic&quot;</li>
-          <li>fatal&quot;</li>
+          <li>&quot;fatal&quot;</li>
           <li>&quot;error&quot;</li>
           <li>&quot;warn&quot;</li>
           <li>&quot;info&quot;</li>


### PR DESCRIPTION
<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/docs-horusec/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Fixed typos on the log-level flag description on both languages (PT-BR and EN-US) on the CLI Commands & Flags session page.
**- How to verify it**
not applied
**- Description for the changelog**
not applied
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
