### PR TITLE
web/install/helm:chore - updating docs with the postgres new version changes

### DIFF
--- a/content/en/web/installation/install-with-helm.md
+++ b/content/en/web/installation/install-with-helm.md
@@ -91,11 +91,18 @@ If you have already installed `PostgreSQL` and `RabbitMQ` with Bitnami's Charts,
 
 ```bash
 export POSTGRES_USERNAME="postgres"
-export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode)
 export RABBITMQ_USERNAME="user"
 export RABBITMQ_PASSWORD=$(kubectl get secret --namespace horusec-system rabbitmq -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
 export JWT_SECRET="4ff42f67-5929-fc52-65f1-3afc77ad86d5"
 ```
+
+If your postgres helm chart is in a version < 11.0.0, the password export must be done as follows:
+
+```bash
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+```
+
 {{% /alert %}}
 
 **Step 3:** Create Kubernetes' Secrets: 

--- a/content/pt-br/web/installation/install-with-helm.md
+++ b/content/pt-br/web/installation/install-with-helm.md
@@ -92,11 +92,18 @@ Se já tiver instalado o `PostgreSQL` e o `RabbitMQ` com os Charts da Bitnami ba
 
 ```bash
 export POSTGRES_USERNAME="postgres"
-export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgres-password}" | base64 --decode)
 export RABBITMQ_USERNAME="user"
 export RABBITMQ_PASSWORD=$(kubectl get secret --namespace horusec-system rabbitmq -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
 export JWT_SECRET="4ff42f67-5929-fc52-65f1-3afc77ad86d5"
 ```
+
+Caso seu helm chart do postgres esteja em uma versão < 11.0.0, o export da senha deve ser feito de seguinte maneira:
+
+```bash
+export POSTGRES_PASSWORD=$(kubectl get secret --namespace horusec-system postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+```
+
 {{% /alert %}}
 
 **Passo 3:** Crie o segredo (Secrets) do Kubernetes:


### PR DESCRIPTION
Postgres helm chart in versions >= 11.0.0 had some changes in name of the
keys where the data was stored. This let our doc outdate on how to
export the postgres password. This pull request adds a explanation for
the new and old version.

Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/docs-horusec/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
