### PR TITLE
change feedback URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -175,8 +175,8 @@ main_slug_to_hide_secondary = "docspt-br"
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/ZupIT/horusec-docs/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/ZupIT/horusec-docs/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
 # If you want this feature, but occasionally need to remove the Reading time from a single page, 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16578570/178156838-a8a84148-c9bd-4ee2-a177-577725d532bf.png)

is pointing to `https://github.com/USERNAME/REPOSITORY/issues/new`, this PR fixes this

However nor issues nor discussions tab are enable on this repository